### PR TITLE
Replaced the default FolderBrowserDialog with a better version

### DIFF
--- a/Symlink Creator/MainWindow.Designer.cs
+++ b/Symlink Creator/MainWindow.Designer.cs
@@ -32,7 +32,7 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainWindow));
             this.label1 = new System.Windows.Forms.Label();
             this.linkLocationTextBox = new System.Windows.Forms.TextBox();
-            this.folderBrowser = new System.Windows.Forms.FolderBrowserDialog();
+            this.folderBrowser = new Microsoft.WindowsAPICodePack.Dialogs.CommonOpenFileDialog();
             this.exploreButton1 = new System.Windows.Forms.Button();
             this.label2 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -79,8 +79,7 @@
             // 
             // folderBrowser
             // 
-            this.folderBrowser.Description = "Please select a folder";
-            this.folderBrowser.ShowNewFolderButton = false;
+            this.folderBrowser.IsFolderPicker = true;
             // 
             // exploreButton1
             // 
@@ -269,7 +268,7 @@
 
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TextBox linkLocationTextBox;
-        private System.Windows.Forms.FolderBrowserDialog folderBrowser;
+        private Microsoft.WindowsAPICodePack.Dialogs.CommonOpenFileDialog folderBrowser;
         private System.Windows.Forms.Button exploreButton1;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.GroupBox groupBox1;

--- a/Symlink Creator/MainWindow.cs
+++ b/Symlink Creator/MainWindow.cs
@@ -9,6 +9,7 @@
 
 namespace Symlink_Creator
 {
+    using Microsoft.WindowsAPICodePack.Dialogs;
     using System;
     using System.Deployment.Application;
     using System.Diagnostics;
@@ -281,8 +282,8 @@ namespace Symlink_Creator
 
         private void ExploreButton1Click(object sender, EventArgs e)
         {
-            this.folderBrowser.ShowDialog();
-            this.linkLocationTextBox.Text = this.folderBrowser.SelectedPath;
+            if (this.folderBrowser.ShowDialog() == CommonFileDialogResult.Ok)
+                this.linkLocationTextBox.Text = this.folderBrowser.FileName;
         }
 
         private void Explorebutton2Click(object sender, EventArgs e)
@@ -290,13 +291,13 @@ namespace Symlink_Creator
             // if folder is true the folder browser will be shown
             if (this.folder)
             {
-                this.folderBrowser.ShowDialog();
-                this.destinationLocationTextBox.Text = this.folderBrowser.SelectedPath;
+                if (this.folderBrowser.ShowDialog() == CommonFileDialogResult.Ok)
+                    this.destinationLocationTextBox.Text = this.folderBrowser.FileName;
             }
             else
             {
-                this.filesBrowser.ShowDialog();
-                this.destinationLocationTextBox.Text = this.filesBrowser.FileName;
+                if (this.folderBrowser.ShowDialog() == CommonFileDialogResult.Ok)
+                    this.destinationLocationTextBox.Text = this.filesBrowser.FileName;
             }
         }
 

--- a/Symlink Creator/Symlink Creator.csproj
+++ b/Symlink Creator/Symlink Creator.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,15 +10,15 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Symlink_Creator</RootNamespace>
     <AssemblyName>Symlink Creator</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ManifestCertificateThumbprint>1545011842E7D72688AF686E0A94663E3A278CFA</ManifestCertificateThumbprint>
     <ManifestKeyFile>cert.pfx</ManifestKeyFile>
-    <GenerateManifests>true</GenerateManifests>
-    <SignManifests>true</SignManifests>
+    <GenerateManifests>false</GenerateManifests>
+    <SignManifests>false</SignManifests>
     <IsWebBootstrapper>true</IsWebBootstrapper>
     <ApplicationIcon>icon.ico</ApplicationIcon>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -61,6 +61,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -71,6 +72,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Symlink Creator.XML</DocumentationFile>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup />
@@ -84,6 +86,12 @@
     <StartupObject>Symlink_Creator.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.3.3, Culture=neutral, PublicKeyToken=8985beaab7ea3f04, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft-WindowsAPICodePack-Core.1.1.3.3\lib\net452\Microsoft.WindowsAPICodePack.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.3.3, Culture=neutral, PublicKeyToken=8985beaab7ea3f04, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft-WindowsAPICodePack-Shell.1.1.3.3\lib\net452\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -125,6 +133,7 @@
     <None Include="app.config" />
     <None Include="cert.pfx" />
     <None Include="key.snk" />
+    <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/Symlink Creator/app.config
+++ b/Symlink Creator/app.config
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
-
 <configuration>
   <startup>
-    <supportedRuntime version="v2.0.50727" />
-  </startup>
+    
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup>
 </configuration>

--- a/Symlink Creator/packages.config
+++ b/Symlink Creator/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft-WindowsAPICodePack-Core" version="1.1.3.3" targetFramework="net452" />
+  <package id="Microsoft-WindowsAPICodePack-Shell" version="1.1.3.3" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Had this on the back burner for a while.

I replaced the stock FolderBrowserDialog with the one found in Microsoft.WindowsAPICodePack.Dialogs.CommonOpenFileDialog. It should make selecting folders more convenient.

Had to retarget the project to .NET 4.5.2 since the API isn't compatible with earlier versions and disable code signing since it was preventing me from compiling the project.

It should fix #19.