### PR TITLE
feat: ⬆️ upgrade to .net10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Build
         run: dotnet build Symlinker/Symlinker.csproj --configuration Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Setup Git
         run: |

--- a/Symlinker/Properties/PublishProfiles/ClickOnceProfile.pubxml
+++ b/Symlinker/Properties/PublishProfiles/ClickOnceProfile.pubxml
@@ -16,7 +16,7 @@
     <MapFileExtensions>True</MapFileExtensions>
     <OpenBrowserOnPublish>False</OpenBrowserOnPublish>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net8.0-windows\app.publish\</PublishDir>
+    <PublishDir>bin\Release\net10.0-windows\app.publish\</PublishDir>
     <PublishUrl>bin\publish\</PublishUrl>
     <PublishProtocol>ClickOnce</PublishProtocol>
     <PublishReadyToRun>False</PublishReadyToRun>
@@ -25,7 +25,7 @@
     <SignatureAlgorithm>(none)</SignatureAlgorithm>
     <SignManifests>False</SignManifests>
     <SkipPublishVerification>false</SkipPublishVerification>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UpdateEnabled>True</UpdateEnabled>
     <UpdateMode>Foreground</UpdateMode>
     <UpdateRequired>False</UpdateRequired>

--- a/Symlinker/Properties/PublishProfiles/ClickOnceProfile.pubxml
+++ b/Symlinker/Properties/PublishProfiles/ClickOnceProfile.pubxml
@@ -3,7 +3,7 @@
 <Project>
   <PropertyGroup>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>4.0.0.0</ApplicationVersion>
+    <ApplicationVersion>4.1.0.0</ApplicationVersion>
     <BootstrapperEnabled>True</BootstrapperEnabled>
     <Configuration>Release</Configuration>
     <CreateWebPageOnPublish>True</CreateWebPageOnPublish>

--- a/Symlinker/Symlinker.csproj
+++ b/Symlinker/Symlinker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <RootNamespace>Symlinker</RootNamespace>
     <GenerateManifests>false</GenerateManifests>
@@ -38,7 +38,7 @@
     <StartupObject>Symlinker.Program</StartupObject>
     <Version>4.0.0.0</Version>
     <Description>Symlinker: The Symbolic link creator</Description>
-    <Copyright>Copyright © Alejandro Mora 2025</Copyright>
+    <Copyright>Copyright © Alejandro Mora 2026</Copyright>
     <PackageProjectUrl>https://github.com/amd989/Symlinker</PackageProjectUrl>
     <RepositoryUrl>https://github.com/amd989/Symlinker/</RepositoryUrl>
     <PackageIconUrl />

--- a/Symlinker/Symlinker.csproj
+++ b/Symlinker/Symlinker.csproj
@@ -36,7 +36,7 @@
     <TargetZone>LocalIntranet</TargetZone>
     <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
     <StartupObject>Symlinker.Program</StartupObject>
-    <Version>4.0.0.0</Version>
+    <Version>4.1.0.0</Version>
     <Description>Symlinker: The Symbolic link creator</Description>
     <Copyright>Copyright © Alejandro Mora 2026</Copyright>
     <PackageProjectUrl>https://github.com/amd989/Symlinker</PackageProjectUrl>


### PR DESCRIPTION
User brought up that .net8 is EOL in November 2026. Preemptively moving to .net10 LTSC to push support forward.